### PR TITLE
Use console.warn for error messages

### DIFF
--- a/jsplayground.go
+++ b/jsplayground.go
@@ -164,9 +164,8 @@ func (g *Go) Format(src string, imports bool) *js.Object {
 var getting = make(map[string]struct{})
 
 func imports() {
-	err := important.Imports()
-	if err != nil {
-		println("additional imports: " + err.Error())
+	if err := important.Imports(); err != nil {
+		js.Global.Get("console").Call("warn", "additional imports: " + err.Error())
 	}
 }
 


### PR DESCRIPTION
I was confused the message when `imports.json` was not found. This PR makes jsplayground use `console.warn` instead of `printf` to clarify the message intention.